### PR TITLE
add default arguments to as.data.frame.disk.frame

### DIFF
--- a/R/as.data.frame.r
+++ b/R/as.data.frame.r
@@ -10,7 +10,7 @@
 #' 
 #' # clean up
 #' delete(cars.df)
-as.data.frame.disk.frame <- function(x, row.names, optional, ...) { # needs to retain x for consistency
+as.data.frame.disk.frame <- function(x, row.names = NULL, optional = FALSE, ...) { # needs to retain x for consistency
   as.data.frame(collect(x), row.names, optional, ...)
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/Rdatatable/data.table/issues/5533 the revdep of `disk.frame` is failing with the current dev version of `data.table`.

This PR solves this problem by adding default values to the arguments of `as.data.frame.disk.frame` method equal to the default values of the generic `as.data.frame` method.